### PR TITLE
Scrape outdated revision of 2013 members table

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -86,14 +86,17 @@ new_format_terms = {
   '2013' => 'https://en.wikipedia.org/wiki/List_of_members_of_the_parliament_of_Iceland,_2013%E2%80%9316',
 }
 
-new_format_terms.each do |term, url|
-  page = MembersPageWithAreaTable.new(response: Scraped::Request.new(url: url).response)
-  members = page.members.each { |m| m[:term] = term }
-  # puts members
-  puts "#{term}: #{members.count}"
-  ScraperWiki.save_sqlite(%i(name term), members)
+def scrape_new_format_terms(terms)
+  terms.each do |term, url|
+    page = MembersPageWithAreaTable.new(response: Scraped::Request.new(url: url).response)
+    members = page.members.each { |m| m[:term] = term }
+    # puts members
+    puts "#{term}: #{members.count}"
+    ScraperWiki.save_sqlite(%i(name term), members)
+  end
 end
 
+scrape_new_format_terms(new_format_terms)
 # ----------
 # Old layout
 # ----------

--- a/scraper.rb
+++ b/scraper.rb
@@ -82,8 +82,8 @@ ScraperWiki.sqliteexecute('DELETE FROM data') rescue nil
 # ----------
 
 new_format_terms = {
-  '2016' => 'https://en.wikipedia.org/wiki/List_of_members_of_the_parliament_of_Iceland',
-  '2013' => 'https://en.wikipedia.org/wiki/List_of_members_of_the_parliament_of_Iceland,_2013%E2%80%9316',
+  '2016' => 'https://en.wikipedia.org/wiki/Template:MembersAlthing2016',
+  '2013' => 'https://en.wikipedia.org/wiki/Template:MembersAlthing2013',
 }
 
 old_revisions = {

--- a/scraper.rb
+++ b/scraper.rb
@@ -86,6 +86,10 @@ new_format_terms = {
   '2013' => 'https://en.wikipedia.org/wiki/List_of_members_of_the_parliament_of_Iceland,_2013%E2%80%9316',
 }
 
+old_revisions = {
+  '2013' => 'https://en.wikipedia.org/w/index.php?title=Template:MembersAlthing2013&direction=prev&oldid=714280236',
+}
+
 def scrape_new_format_terms(terms)
   terms.each do |term, url|
     page = MembersPageWithAreaTable.new(response: Scraped::Request.new(url: url).response)
@@ -97,6 +101,8 @@ def scrape_new_format_terms(terms)
 end
 
 scrape_new_format_terms(new_format_terms)
+scrape_new_format_terms(old_revisions)
+
 # ----------
 # Old layout
 # ----------


### PR DESCRIPTION
We were losing Jón Þór Ólafsson in the data import as he was removed
from the 2013 table -- having been replaced by Ásta Guðrún Helgadóttir.

This commit adds and scrapes the last revision of the 2013 table in which he appears.

## [Scraper Change checklist](https://github.com/everypolitician/everypolitician/wiki/Scraper-Change-checklist)
* [x] 1. scraper is on Morph.io under the "everypolitician-scrapers" group?
* [x] 2. scraper's GitHub "Website" link points at morph.io page?
* [x] 3. scraper is set to auto-run?
* ~[ ] 4.scraper is archiving?~ No need. Source is wikipedia.
* [x] 5. legislature has a scraper webhook set?

Note to reviewer: I have moved the scraper on morph from tmtmtmtm/ to everypolitician-scrapers/