### PR TITLE
Scrape templates instead of containing pages

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -82,8 +82,8 @@ ScraperWiki.sqliteexecute('DELETE FROM data') rescue nil
 # ----------
 
 new_format_terms = {
-  '2016' => 'https://en.wikipedia.org/wiki/List_of_members_of_the_parliament_of_Iceland',
-  '2013' => 'https://en.wikipedia.org/wiki/List_of_members_of_the_parliament_of_Iceland,_2013%E2%80%9316',
+  '2016' => 'https://en.wikipedia.org/wiki/Template:MembersAlthing2016',
+  '2013' => 'https://en.wikipedia.org/wiki/Template:MembersAlthing2013',
 }
 
 new_format_terms.each do |term, url|


### PR DESCRIPTION
This is a step towards scraping historic data from a past edit of the 2013 members template. (The historic data can only be accessed in the template revision history.)

We will want to scrape data directly from all templates so to harmonize the sources.