### PR TITLE
Scrape historic revision of 2013 term table

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -60,7 +60,7 @@ class MembersPageWithAreaTable < Scraped::HTML
           wikipedia:    wikilink(p),
           constituency: constituencies[i],
           party:        Party.new(p.xpath('./following-sibling::text()').first.text).name,
-          term:         url[-4..-1],
+          term:         url.split('&').first[-4..-1],
           start_date:   nil,
           end_date:     nil,
         }
@@ -210,5 +210,4 @@ scrape_new_format_terms(urls)
     ScraperWiki.save_sqlite(%i(name term), data)
     (ScraperWiki.save_sqlite(%i(name term), replacement) && count += 1) if replacement
   end
-  puts "#{term}: #{count}"
 end

--- a/scraper.rb
+++ b/scraper.rb
@@ -86,27 +86,21 @@ ScraperWiki.sqliteexecute('DELETE FROM data') rescue nil
 # New layout
 # ----------
 
-new_terms = {
-  '2016' => 'https://en.wikipedia.org/wiki/Template:MembersAlthing2016',
-  '2013' => 'https://en.wikipedia.org/wiki/Template:MembersAlthing2013',
-}
+urls = [
+  'https://en.wikipedia.org/wiki/Template:MembersAlthing2016',
+  'https://en.wikipedia.org/wiki/Template:MembersAlthing2013',
+  'https://en.wikipedia.org/w/index.php?title=Template:MembersAlthing2013&direction=prev&oldid=714280236',
+]
 
-old_revisions = {
-  '2013' => 'https://en.wikipedia.org/w/index.php?title=Template:MembersAlthing2013&direction=prev&oldid=714280236',
-}
-
-def scrape_new_format_terms(*term_hashes)
-  term_hashes.each do |term_hash|
-    term_hash.each do |term, url|
-      members = (scrape url => MembersPageWithAreaTable).members.each do |m|
-        ScraperWiki.save_sqlite(%i(name term), m.merge(term: term))
-      end
-      puts "#{term}: #{members.count}"
+def scrape_new_format_terms(urls)
+  urls.each do |url|
+    (scrape url => MembersPageWithAreaTable).members.each do |m|
+      ScraperWiki.save_sqlite(%i(name term), m.to_h)
     end
   end
 end
 
-scrape_new_format_terms(new_terms, old_revisions)
+scrape_new_format_terms(urls)
 
 # ----------
 # Old layout

--- a/scraper.rb
+++ b/scraper.rb
@@ -60,7 +60,7 @@ class MembersPageWithAreaTable < Scraped::HTML
           wikipedia:    wikilink(p),
           constituency: constituencies[i],
           party:        Party.new(p.xpath('./following-sibling::text()').first.text).name,
-          term:         nil, # splice in later
+          term:         url[-4..-1],
           start_date:   nil,
           end_date:     nil,
         }


### PR DESCRIPTION
We were losing Jón Þór Ólafsson in the data import as he was removed
from the 2013 table -- having been replaced by Ásta Guðrún Helgadóttir.

This commit adds and scrapes the last revision of the 2013 table in which he appears.

## [Scraper Change checklist](https://github.com/everypolitician/everypolitician/wiki/Scraper-Change-checklist)
* [x] 1. scraper is on Morph.io under the "everypolitician-scrapers" group?
* [x] 2. scraper's GitHub "Website" link points at morph.io page?
* [x] 3. scraper is set to auto-run?
* ~[ ] 4.scraper is archiving?~ No need. Source is wikipedia.
* [x] 5. legislature has a scraper webhook set?