### PR TITLE
Remove table from database before scraping

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -75,7 +75,7 @@ class MembersPageWithAreaTable < Scraped::HTML
 end
 
 # Clean out old data and start fresh each time
-ScraperWiki.sqliteexecute('DELETE FROM data') rescue nil
+ScraperWiki.sqliteexecute('DROP TABLE data') rescue nil
 
 # ----------
 # New layout


### PR DESCRIPTION
SqliteMagic creates a unique index at CREATE TABLE time. This means that if the unique index arguments of ScraperWiki.save_sqlite change, we need to create a new table to ensure the db reflects the change.

Part of: https://github.com/everypolitician/everypolitician/issues/593